### PR TITLE
metrics: add option to set scope attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ Flags:
 
       --otlp-endpoint=STRING             OTLP endpoint ($OTEL_EXPORTER_OTLP_ENDPOINT,
                                          $OTEL_EXPORTER_OTLP_METRICS_ENDPOINT)
-      --otlp-headers=KEY=VALUE,...       OTLP headers ($OTEL_EXPORTER_OTLP_HEADERS, $OTEL_EXPORTER_OTLP_METRICS_HEADERS)
+      --otlp-headers=KEY=VALUE,...       OTLP headers ($OTEL_EXPORTER_OTLP_HEADERS,
+                                         $OTEL_EXPORTER_OTLP_METRICS_HEADERS)
       --otlp-protocol="grpc"             OTLP protocol ($OTEL_EXPORTER_OTLP_PROTOCOL)
       --otlp-insecure                    disable secure connection (required for such as localhost)
   -n, --name=STRING                      metric name
@@ -58,6 +59,7 @@ Flags:
       --scope-name=STRING                instrumentation scope name
       --scope-version=STRING             instrumentation scope version
       --scope-schemaurl=STRING           instrumentation scope schema url
+      --scope-attrs=KEY=VALUE,...        instrumentation scope attributes
       --datapoint-attrs=KEY=VALUE,...    datapoint attributes (--attrs is an alias)
       --timestamp=INT-64                 datapoint timestamp (unix seconds)
 ```

--- a/internal/cli/metricspostcmd.go
+++ b/internal/cli/metricspostcmd.go
@@ -23,6 +23,7 @@ type MetricsPostCmd struct {
 	ScopeName          string            `name:"scope-name" help:"instrumentation scope name"`
 	ScopeVersion       string            `name:"scope-version" help:"instrumentation scope version"`
 	ScopeSchemaURL     string            `name:"scope-schemaurl" help:"instrumentation scope schema url"`
+	ScopeAttrs         map[string]string `name:"scope-attrs" mapsep:"," help:"instrumentation scope attributes"`
 	DataPointAttrs     map[string]string `name:"datapoint-attrs" mapsep:"," aliases:"attrs" help:"datapoint attributes (--attrs is an alias)"`
 	DataPointTimestamp int64             `name:"timestamp" help:"datapoint timestamp (unix seconds)"`
 	DataPointValue     float64           `arg:"" required:"" help:"datapoint value"`
@@ -54,6 +55,7 @@ func (c *MetricsPostCmd) Run(globals *Globals) error {
 		ScopeName:      c.ScopeName,
 		ScopeVersion:   c.ScopeVersion,
 		ScopeSchemaURL: c.ScopeSchemaURL,
+		ScopeAttrs:     c.ScopeAttrs,
 	})
 
 	resourceMetrics, err := metric.Generate(&metric.GenerateParams{

--- a/internal/scope/generate.go
+++ b/internal/scope/generate.go
@@ -1,18 +1,27 @@
 package scope
 
-import "go.opentelemetry.io/otel/sdk/instrumentation"
+import (
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/instrumentation"
+)
 
 type GenerateParams struct {
 	ScopeName      string
 	ScopeVersion   string
 	ScopeSchemaURL string
+	ScopeAttrs     map[string]string
 }
 
 func Generate(p *GenerateParams) instrumentation.Scope {
+	attributes := make([]attribute.KeyValue, 0, len(p.ScopeAttrs))
+	for k, v := range p.ScopeAttrs {
+		attributes = append(attributes, attribute.String(k, v))
+	}
 	s := instrumentation.Scope{
-		Name:      p.ScopeName,
-		Version:   p.ScopeVersion,
-		SchemaURL: p.ScopeSchemaURL,
+		Name:       p.ScopeName,
+		Version:    p.ScopeVersion,
+		SchemaURL:  p.ScopeSchemaURL,
+		Attributes: attribute.NewSet(attributes...),
 	}
 	return s
 }

--- a/internal/scope/generate_test.go
+++ b/internal/scope/generate_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/instrumentation"
 )
 
@@ -26,11 +27,13 @@ func TestGenerate(t *testing.T) {
 				ScopeName:      "github.com/Arthur1/otlc",
 				ScopeVersion:   "0.0.0",
 				ScopeSchemaURL: "https://opentelemetry.io/schemas/1.4.0",
+				ScopeAttrs:     map[string]string{"short_name": "otlc"},
 			},
 			want: instrumentation.Scope{
-				Name:      "github.com/Arthur1/otlc",
-				Version:   "0.0.0",
-				SchemaURL: "https://opentelemetry.io/schemas/1.4.0",
+				Name:       "github.com/Arthur1/otlc",
+				Version:    "0.0.0",
+				SchemaURL:  "https://opentelemetry.io/schemas/1.4.0",
+				Attributes: attribute.NewSet(attribute.String("short_name", "otlc")),
 			},
 		},
 	}
@@ -40,7 +43,7 @@ func TestGenerate(t *testing.T) {
 			t.Parallel()
 			got := Generate(tt.in)
 			testutil.NoDiff(t, tt.want, got, []cmp.Option{cmpopts.IgnoreFields(instrumentation.Scope{}, "Attributes")}, "instrumentation scope should be equal but has diff")
-			assert.True(t, tt.want.Attributes.Equals(&got.Attributes), "instrumentation scope attributes should be equal but has diff: %s", cmp.Diff(got.Attributes.ToSlice(), tt.want.Attributes.ToSlice()))
+			assert.True(t, tt.want.Attributes.Equals(&got.Attributes), "instrumentation scope attributes should be equal but has diff\n want: %+v\ngot: %+v", tt.want.Attributes.ToSlice(), got.Attributes.ToSlice())
 		})
 	}
 }


### PR DESCRIPTION


```console
$ go run ./cmd/otlc/main.go metrics post --name=awesome.gauge --scope-attrs=hoge=1,fuga=2 100
exported.
```