### PR TITLE
add the feature to parse URL path

### DIFF
--- a/internal/metric/export.go
+++ b/internal/metric/export.go
@@ -3,6 +3,8 @@ package metric
 import (
 	"context"
 	"fmt"
+	"net/url"
+	"strings"
 
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
@@ -31,13 +33,22 @@ func NewExporter(p *NewExporterParams) (sdkmetric.Exporter, error) {
 		exporter, err := otlpmetricgrpc.New(context.Background(), options...)
 		return exporter, err
 	case "http":
+		if !strings.Contains(p.OTLPEndpoint, "://") {
+			p.OTLPEndpoint = "https://" + p.OTLPEndpoint
+		}
+		u, err := url.Parse(p.OTLPEndpoint)
+		if err != nil {
+			return nil, fmt.Errorf("invalid OTLP endpoint URL: %w", err)
+		}
+
 		options := []otlpmetrichttp.Option{
-			otlpmetrichttp.WithEndpoint(p.OTLPEndpoint),
+			otlpmetrichttp.WithEndpoint(u.Host),
+			otlpmetrichttp.WithURLPath(u.Path),
 		}
 		if len(p.OTLPHeaders) > 0 {
 			options = append(options, otlpmetrichttp.WithHeaders(p.OTLPHeaders))
 		}
-		if p.OTLPInsecure {
+		if p.OTLPInsecure || u.Scheme == "http" {
 			options = append(options, otlpmetrichttp.WithInsecure())
 		}
 		exporter, err := otlpmetrichttp.New(context.Background(), options...)

--- a/internal/metric/export_test.go
+++ b/internal/metric/export_test.go
@@ -35,6 +35,30 @@ func TestNewExporter(t *testing.T) {
 		// TODO: test with dummy server
 	})
 
+	t.Run("returns otlpmetrichttp.Exporter (with scheme and custom path)", func(t *testing.T) {
+		t.Parallel()
+		params := &NewExporterParams{
+			OTLPProtocol: "http",
+			OTLPEndpoint: "http://localhost:4318/custom/path/v1/metrics",
+		}
+
+		got, err := NewExporter(params)
+		assert.NoError(t, err)
+		assert.IsType(t, got, &otlpmetrichttp.Exporter{})
+	})
+
+	t.Run("returns otlpmetrichttp.Exporter (no scheme, with custom path)", func(t *testing.T) {
+		t.Parallel()
+		params := &NewExporterParams{
+			OTLPProtocol: "http",
+			OTLPEndpoint: "localhost:4318/custom/path/v1/metrics",
+		}
+
+		got, err := NewExporter(params)
+		assert.NoError(t, err)
+		assert.IsType(t, got, &otlpmetrichttp.Exporter{})
+	})
+
 	t.Run("returns error when unexpected protocol is passed", func(t *testing.T) {
 		t.Parallel()
 		params := &NewExporterParams{


### PR DESCRIPTION
こんにちは。otlcでgrpcではなくhttpを使ったときにつまずいたので、提案PRをお送りします。

背景

- PrometheusのOTLP endpoint `http://localhost:9090/api/v1/otlp/v1/metrics` に投稿しようとしたところ、スキーム `http://` があるためにWithEndpointが失敗し、さらに`http://`を消しても `/api/v1` 以降が余計とされてやはり失敗しました。

このPRでの対処

- url.Parseを使った分解を行い、WithURLPathにパス部を渡すようにしました。
- スキームが `http` だった場合はOTLPInsecure指定がなくてもinsecureモードとするようにしてみました。
- 後方互換性のために、エンドポイントにスキーム指定がなかったときには `https://` を補足するようにしました。(後方互換性を無視するなら、いっそスキーム有無でgRPC/http分けてもいいのかもしれませんが)
